### PR TITLE
Add Node.js ERP backend skeleton

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,2 +1,40 @@
 # Contabilidad
-Contabilidad
+
+Este repositorio contiene un esqueleto de backend para un sistema de ERP. El backend está construido con **Node.js** y **Express** y agrupa distintas áreas contables y administrativas.
+
+## Estructura
+
+- `backend/` código fuente del servidor
+  - `src/app.js` punto de entrada de la aplicación
+  - `src/routes/` define las rutas de cada módulo
+  - `src/controllers/` contiene las funciones que responden a cada ruta
+  - `src/models/` espacio para modelos de datos (actualmente vacío)
+
+## Funcionalidades incluidas
+
+- Libro de compras y ventas automático
+- Envío de DTE al SII (facturas, boletas, NC, ND)
+- Informes financieros y contables
+- Gestión de clientes y proveedores
+- Emisión de cotizaciones y órdenes de compra
+- Conciliación bancaria
+- Remuneraciones y liquidaciones
+
+Cada módulo expone rutas HTTP que actualmente devuelven mensajes de ejemplo. Sirven como base para incorporar la lógica real en el futuro.
+
+## Uso
+
+1. Instalar dependencias (requiere conexión a internet):
+
+   ```bash
+   cd backend
+   npm install
+   ```
+
+2. Iniciar el servidor:
+
+   ```bash
+   npm start
+   ```
+
+El servidor escucha por defecto en el puerto `3000`.

--- a/backend/package.json
+++ b/backend/package.json
@@ -1,0 +1,17 @@
+{
+  "name": "backend",
+  "version": "1.0.0",
+  "description": "ERP backend skeleton",
+  "main": "src/app.js",
+  "scripts": {
+    "start": "node src/app.js",
+    "test": "echo \"No tests specified\" && exit 0"
+  },
+  "keywords": [],
+  "author": "",
+  "license": "ISC",
+  "type": "commonjs",
+  "dependencies": {
+    "express": "^4.18.2"
+  }
+}

--- a/backend/src/app.js
+++ b/backend/src/app.js
@@ -1,0 +1,33 @@
+const express = require('express');
+const app = express();
+app.use(express.json());
+
+// Routers
+const purchasesRouter = require('./routes/purchases');
+const salesRouter = require('./routes/sales');
+const dteRouter = require('./routes/dte');
+const reportsRouter = require('./routes/reports');
+const clientsRouter = require('./routes/clients');
+const quotesRouter = require('./routes/quotes');
+const bankingRouter = require('./routes/banking');
+const payrollRouter = require('./routes/payroll');
+
+app.use('/purchases', purchasesRouter);
+app.use('/sales', salesRouter);
+app.use('/dte', dteRouter);
+app.use('/reports', reportsRouter);
+app.use('/clients', clientsRouter);
+app.use('/quotes', quotesRouter);
+app.use('/banking', bankingRouter);
+app.use('/payroll', payrollRouter);
+
+app.get('/', (req, res) => {
+  res.json({ message: 'ERP Backend API' });
+});
+
+const PORT = process.env.PORT || 3000;
+app.listen(PORT, () => {
+  console.log(`Server running on port ${PORT}`);
+});
+
+module.exports = app;

--- a/backend/src/controllers/banking.js
+++ b/backend/src/controllers/banking.js
@@ -1,0 +1,3 @@
+exports.reconcile = (req, res) => {
+  res.json({ message: 'Bank reconciliation - placeholder' });
+};

--- a/backend/src/controllers/clients.js
+++ b/backend/src/controllers/clients.js
@@ -1,0 +1,7 @@
+exports.list = (req, res) => {
+  res.json({ message: 'List of clients/providers - placeholder' });
+};
+
+exports.create = (req, res) => {
+  res.json({ message: 'Create client/provider - placeholder' });
+};

--- a/backend/src/controllers/dte.js
+++ b/backend/src/controllers/dte.js
@@ -1,0 +1,3 @@
+exports.send = (req, res) => {
+  res.json({ message: 'Send DTE to SII - placeholder' });
+};

--- a/backend/src/controllers/payroll.js
+++ b/backend/src/controllers/payroll.js
@@ -1,0 +1,7 @@
+exports.paychecks = (req, res) => {
+  res.json({ message: 'Payroll reports - placeholder' });
+};
+
+exports.create = (req, res) => {
+  res.json({ message: 'Create paycheck - placeholder' });
+};

--- a/backend/src/controllers/purchases.js
+++ b/backend/src/controllers/purchases.js
@@ -1,0 +1,7 @@
+exports.list = (req, res) => {
+  res.json({ message: 'List of purchases - placeholder' });
+};
+
+exports.create = (req, res) => {
+  res.json({ message: 'Create purchase - placeholder' });
+};

--- a/backend/src/controllers/quotes.js
+++ b/backend/src/controllers/quotes.js
@@ -1,0 +1,7 @@
+exports.list = (req, res) => {
+  res.json({ message: 'List of quotations/orders - placeholder' });
+};
+
+exports.create = (req, res) => {
+  res.json({ message: 'Create quotation/order - placeholder' });
+};

--- a/backend/src/controllers/reports.js
+++ b/backend/src/controllers/reports.js
@@ -1,0 +1,7 @@
+exports.financial = (req, res) => {
+  res.json({ message: 'Financial reports - placeholder' });
+};
+
+exports.accounting = (req, res) => {
+  res.json({ message: 'Accounting reports - placeholder' });
+};

--- a/backend/src/controllers/sales.js
+++ b/backend/src/controllers/sales.js
@@ -1,0 +1,7 @@
+exports.list = (req, res) => {
+  res.json({ message: 'List of sales - placeholder' });
+};
+
+exports.create = (req, res) => {
+  res.json({ message: 'Create sale - placeholder' });
+};

--- a/backend/src/routes/banking.js
+++ b/backend/src/routes/banking.js
@@ -1,0 +1,7 @@
+const express = require('express');
+const router = express.Router();
+const bankingController = require('../controllers/banking');
+
+router.post('/reconcile', bankingController.reconcile);
+
+module.exports = router;

--- a/backend/src/routes/clients.js
+++ b/backend/src/routes/clients.js
@@ -1,0 +1,8 @@
+const express = require('express');
+const router = express.Router();
+const clientsController = require('../controllers/clients');
+
+router.get('/', clientsController.list);
+router.post('/', clientsController.create);
+
+module.exports = router;

--- a/backend/src/routes/dte.js
+++ b/backend/src/routes/dte.js
@@ -1,0 +1,7 @@
+const express = require('express');
+const router = express.Router();
+const dteController = require('../controllers/dte');
+
+router.post('/send', dteController.send);
+
+module.exports = router;

--- a/backend/src/routes/payroll.js
+++ b/backend/src/routes/payroll.js
@@ -1,0 +1,8 @@
+const express = require('express');
+const router = express.Router();
+const payrollController = require('../controllers/payroll');
+
+router.get('/paychecks', payrollController.paychecks);
+router.post('/paychecks', payrollController.create);
+
+module.exports = router;

--- a/backend/src/routes/purchases.js
+++ b/backend/src/routes/purchases.js
@@ -1,0 +1,8 @@
+const express = require('express');
+const router = express.Router();
+const purchasesController = require('../controllers/purchases');
+
+router.get('/', purchasesController.list);
+router.post('/', purchasesController.create);
+
+module.exports = router;

--- a/backend/src/routes/quotes.js
+++ b/backend/src/routes/quotes.js
@@ -1,0 +1,8 @@
+const express = require('express');
+const router = express.Router();
+const quotesController = require('../controllers/quotes');
+
+router.get('/', quotesController.list);
+router.post('/', quotesController.create);
+
+module.exports = router;

--- a/backend/src/routes/reports.js
+++ b/backend/src/routes/reports.js
@@ -1,0 +1,8 @@
+const express = require('express');
+const router = express.Router();
+const reportsController = require('../controllers/reports');
+
+router.get('/financial', reportsController.financial);
+router.get('/accounting', reportsController.accounting);
+
+module.exports = router;

--- a/backend/src/routes/sales.js
+++ b/backend/src/routes/sales.js
@@ -1,0 +1,8 @@
+const express = require('express');
+const router = express.Router();
+const salesController = require('../controllers/sales');
+
+router.get('/', salesController.list);
+router.post('/', salesController.create);
+
+module.exports = router;


### PR DESCRIPTION
## Summary
- scaffold Node.js/Express backend under `backend/`
- add placeholder controllers and routes for ERP modules
- document features and usage steps in README

## Testing
- `npm test`
- `npm start` *(fails: Cannot find module 'express')*

------
https://chatgpt.com/codex/tasks/task_e_687996ff2594832ab5794c62510eb40e